### PR TITLE
fixed modifyFightSkill descriptor

### DIFF
--- a/src/org/luceat/wu/mods/skillmod/SkillMod.java
+++ b/src/org/luceat/wu/mods/skillmod/SkillMod.java
@@ -20,7 +20,7 @@ public class SkillMod implements WurmMod, Configurable, PreInitable {
     private double lowerStatDivider = 5.0D;
     private double upperStatDivider = 45.0D;
     private final String modifyFightSkillMethodName = "modifyFightSkill";
-    private final String modifyFightSkillMethodDesc = "()Z";
+    private final String modifyFightSkillMethodDesc = "(II)Z";
     private final String checkAdvanceMethodName = "checkAdvance";
     private final String checkAdvanceMethodDesc = "(DLcom/wurmonline/server/items/Item;DZFZD)D";
     private final String setKnowledgeMethodName = "setKnowledge";


### PR DESCRIPTION
The signature of that method changed at some point in WU, and it crashes if fightskill modification is enabled.
